### PR TITLE
feat: Add intelligent entrypoint for Docker agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,12 @@ ENV PYTHONUNBUFFERED=1
 # Define o diretório de trabalho dentro do contêiner
 WORKDIR /app
 
-# Atualiza os pacotes do sistema operacional e instala o Node.js e o npm (que inclui o npx)
+# Atualiza os pacotes do sistema operacional e instala as dependências necessárias:
+# - nodejs e npm: para o npx
+# - curl: para verificar a API
+# - jq: para processar a resposta JSON da API
 # O `-y` confirma a instalação automaticamente.
-RUN apt-get update && apt-get install -y nodejs npm curl
+RUN apt-get update && apt-get install -y nodejs npm curl jq
 
 # Copia os arquivos de dependências para o diretório de trabalho
 COPY requirements.txt requirements.in ./
@@ -21,5 +24,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 # O .dockerignore garantirá que arquivos desnecessários não sejam incluídos.
 COPY . .
 
-# O comando para iniciar a aplicação será definido no docker-compose.yml,
-# pois teremos diferentes comandos para o servidor e para o agente.
+# Copia o script de entrypoint e o torna executável
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+# Define o script de entrypoint como o ponto de entrada do contêiner.
+# O comando a ser executado (CMD) será passado pelo docker-compose.yml.
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -41,9 +41,18 @@ O Docker irá construir a imagem, baixar as dependências e iniciar o servidor d
 
 ### 3. Primeiros Passos com Docker
 
-- **Acesse a Interface do Lemonade:** Para adicionar ou gerenciar seus modelos, abra o navegador e acesse **[http://localhost:8000](http://localhost:8000/#model-management)**.
-- **Use o Agente:** O terminal onde você executou `docker-compose up` se tornará a sua janela de chat com o agente.
-- **Para encerrar:** Pressione `Ctrl + C` no terminal. Para remover os contêineres, execute `docker-compose down`.
+Após executar `docker-compose up`, o processo ocorrerá em duas etapas:
+
+1.  **Instale o Modelo LLM:**
+    *   O terminal do agente mostrará uma mensagem "⏳ Modelo 'user.jan-nano' ainda não encontrado." e ficará em modo de espera.
+    *   Enquanto ele espera, abra seu navegador e acesse a interface do Lemonade em **[http://localhost:8000](http://localhost:8000/#model-management)**.
+    *   Clique em **"Add Model"** e instale o modelo `user.jan-nano` (ou outro de sua preferência, ajustando o `agent.docker.json`).
+
+2.  **Use o Agente:**
+    *   Assim que o modelo for instalado, o terminal do agente irá detectá-lo automaticamente, exibirá a mensagem "✅ Modelo detectado!" e iniciará o agente.
+    *   A partir desse momento, o terminal se tornará sua janela de chat interativa com o agente.
+
+- **Para encerrar:** Pressione `Ctrl + C` no terminal. Para remover os contêineres e o volume de dados, execute `docker-compose down -v`.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     container_name: agent
     # Define o diretório de trabalho para onde estão os arquivos do agente
     working_dir: /app/file-assistant
-    # O comando para iniciar o agente, usando a configuração específica do Docker
-    command: tiny-agents run agent.docker.json
+    # O comando a ser executado pelo entrypoint.sh após o modelo ser detectado.
+    command: ["tiny-agents", "run", "agent.docker.json"]
     depends_on:
       # Garante que o agente só iniciará depois que o servidor estiver pronto
       - lemonade-server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Define a URL da API do Lemonade Server e o caminho do arquivo de configuração do agente
+LEMONADE_API_URL="http://lemonade-server:8000/api/models"
+AGENT_CONFIG_PATH="/app/file-assistant/agent.docker.json"
+
+# Extrai o nome do modelo necessário do arquivo de configuração do agente usando jq
+# O 'jq -r' extrai o valor da string sem as aspas
+MODEL_NAME=$(jq -r '.model' "$AGENT_CONFIG_PATH")
+
+echo "---"
+echo "🤖 Agente aguardando a instalação do modelo: '$MODEL_NAME'"
+echo "---"
+
+# Loop infinito para verificar a disponibilidade do modelo
+while true; do
+    # Usa 'curl' para obter a lista de modelos instalados e 'jq' para verificar se o nosso modelo está na lista
+    # 'curl -s' é para modo silencioso. 'jq -e' retorna um status de saída 0 se encontrar o resultado.
+    if curl -s "$LEMONADE_API_URL" | jq -e --arg model "$MODEL_NAME" '.[] | select(.name == $model)' > /dev/null; then
+        echo "✅ Modelo '$MODEL_NAME' detectado no Lemonade Server!"
+        echo "🚀 Iniciando o agente..."
+        break # Sai do loop
+    else
+        echo "--------------------------------------------------------------------------------"
+        echo "⏳ Modelo '$MODEL_NAME' ainda não encontrado."
+        echo "👉 Por favor, acesse http://localhost:8000, adicione e instale o modelo."
+        echo "   (O agente irá iniciar automaticamente assim que o modelo for detectado)"
+        echo "--------------------------------------------------------------------------------"
+        sleep 15 # Espera 15 segundos antes de verificar novamente
+    fi
+done
+
+# Executa o comando que foi passado para o entrypoint (definido no docker-compose.yml)
+# O 'exec' substitui o processo do script pelo do agente, o que é uma boa prática.
+exec "$@"


### PR DESCRIPTION
This commit introduces an `entrypoint.sh` script to solve the synchronization issue where the agent container would start before the required LLM was installed in the Lemonade Server.

Key changes:
- A new `entrypoint.sh` script now runs when the agent container starts.
- This script polls the Lemonade Server API, checking for the required model specified in `agent.docker.json`.
- It provides clear, user-friendly instructions, prompting the user to install the model via the web UI.
- The agent process (`tiny-agents run`) is only executed after the script confirms the model has been installed.
- The `Dockerfile` has been updated to include `jq` (a new dependency for the entrypoint script) and to set `entrypoint.sh` as the entrypoint.
- The `docker-compose.yml` is adjusted to pass the agent command as an argument to the new entrypoint.
- The `README.md` is updated to explain this new interactive setup flow.