### PR TITLE
fix: Correct Docker entrypoint path to resolve startup error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ COPY . .
 COPY entrypoint.sh .
 RUN chmod +x entrypoint.sh
 
-# Define o script de entrypoint como o ponto de entrada do contêiner.
+# Define o script de entrypoint como o ponto de entrada do contêiner, usando seu caminho absoluto.
 # O comando a ser executado (CMD) será passado pelo docker-compose.yml.
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
This commit fixes a critical bug that prevented the `agent` container from starting when using `docker-compose up`.

The user provided logs showing the error: `stat ./entrypoint.sh: no such file or directory`. The root cause was a conflict between the `working_dir` defined in the `docker-compose.yml` (`/app/file-assistant`) and the relative path used in the `Dockerfile`'s `ENTRYPOINT` instruction (`./entrypoint.sh`). The container was incorrectly looking for the script in the `file-assistant` subdirectory.

The fix involves changing the `ENTRYPOINT` instruction in the `Dockerfile` to use the absolute path of the script: `ENTRYPOINT ["/app/entrypoint.sh"]`. This ensures the script is always found, regardless of the `working_dir` set in `docker-compose.yml`.

This final commit includes this critical fix, along with all previously developed features, including the complete Docker setup and the fully overhauled documentation site.