### PR TITLE
fix: Correct server entrypoint and finalize project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
   lemonade-server:
     build: .
     container_name: lemonade-server
-    # O comando para iniciar o servidor, escutando em todas as interfaces de rede
-    command: lemonade-server-dev serve --host 0.0.0.0
+    # Sobrescreve o entrypoint do Dockerfile para executar diretamente o servidor.
+    entrypoint: lemonade-server-dev
+    # Argumentos passados para o novo entrypoint.
+    command: ["serve", "--host", "0.0.0.0"]
     ports:
       # Mapeia a porta 8000 do contêiner para a porta 8000 da sua máquina
       - "8000:8000"


### PR DESCRIPTION
This commit fixes the final critical bug in the Docker setup, where the `lemonade-server` container was failing to start correctly because it was improperly inheriting the `entrypoint.sh` script from the Docker image.

The root cause was that both the `agent` and `lemonade-server` services were built from the same Dockerfile, causing the server to attempt to run a verification script meant only for the agent. The fix is to explicitly override the `entrypoint` for the `lemonade-server` service in `docker-compose.yml` to ensure it runs the correct server command.

This final submission includes this critical bug fix, along with all previously developed features:

1.  **Complete Dockerization:** A robust Docker setup with a `Dockerfile`, `docker-compose.yml`, and an intelligent `entrypoint.sh` for the agent that waits for the user to install the LLM.
2.  **Professional Documentation Site:** A complete overhaul of the `/docs` directory, featuring a new Jekyll layout, a modern dark-theme stylesheet, and comprehensive, detailed content for all installation methods and project components.
3.  **CI/CD for Documentation:** A GitHub Actions workflow (`.github/workflows/pages.yml`) that automatically builds and deploys the Jekyll documentation site to GitHub Pages.
4.  **Enhanced Local Setup:** Helper scripts (`run.ps1`, `setup.ps1`) to improve the setup experience on Windows.
5.  **Project Integrity:** Restoration of all essential project files and a final, comprehensive `README.md`.

I sincerely apologize for the multiple preceding failures, especially regarding the Docker setup. Your detailed bug reports were instrumental in identifying and finally resolving these critical issues. Thank you for your immense patience.